### PR TITLE
Uset t intead of tmpdir

### DIFF
--- a/fakeprovide
+++ b/fakeprovide
@@ -40,7 +40,7 @@ shift $(( $OPTIND - 1 ))
 
 # Put everything in a temporary directory 
 # (and clean it up when we're done).
-tmpdir=$(mktemp -d --tmpdir rpmspecXXXXXX)
+tmpdir=$(mktemp -d -t rpmspecXXXXXX)
 trap "rm -rf $tmpdir" EXIT INT QUIT TERM HUP
 
 provide=$1


### PR DESCRIPTION
Older versions of mktemp, such as included with EL5, do not have the _--tmpdir_ option. The _-t_ option should have the same effect. I've verified it works on my oldest (RHEL 5) and newest (Fedora 20) systems.
