### PR TITLE
Prevent wordsplitting for package provides

### DIFF
--- a/fakeprovide
+++ b/fakeprovide
@@ -26,7 +26,7 @@ while getopts 'a:s:hSBP:v:' ch; do
 		(s)	RPM_SUMMARY="$OPTARG";;
 		(S)	RPM_BUILD_SOURCE=1;;
 		(B)	RPM_BUILD_BINARY=0;;
-		(P)	RPM_ADDL_PROVIDES+=($OPTARG);;
+		(P)	RPM_ADDL_PROVIDES+=("$OPTARG");;
 		(v)	RPM_VERSION="$OPTARG";;
 		(h)	usage
 			exit 0


### PR DESCRIPTION
If you want to do versioned provides via  -P 'foo = 1.0' wordsplitting kicks in and you will end with 
  Provides: foo
  Provides: =
  Provides: 1.0

Proper quoting of $OPTARG prevents that.