### PR TITLE
Fix issue when specifying architecture for rpmbuild 4.17.1 / Fedora 35:

### DIFF
--- a/fakeprovide
+++ b/fakeprovide
@@ -79,6 +79,7 @@ BuildArch:	$RPM_BUILDARCH
 
 %description
 %{summary}
+%global debug_package %{nil}
 
 %prep
 %setup -c -T
@@ -115,7 +116,7 @@ if [ "$RPM_BUILD_BINARY" = 1 ]; then
 		rpmbuild -bb --define "_topdir $tmpdir/rpmbuild" $tmpdir/fakeprovide.spec > $tmpdir/rpm.log 2>&1 ||
 			die "Failed to build binary RPM." $tmpdir/rpm.log
 	else
-		setarch $RPM_BUILDARCH rpmbuild -bb --define "_topdir $tmpdir/rpmbuild" $tmpdir/fakeprovide.spec > $tmpdir/rpm.log 2>&1 ||
+		setarch $RPM_BUILDARCH rpmbuild --nodebuginfo -bb --define "_topdir $tmpdir/rpmbuild" $tmpdir/fakeprovide.spec > $tmpdir/rpm.log 2>&1 ||
 			die "Failed to build binary RPM." $tmpdir/rpm.log
 	fi
 fi


### PR DESCRIPTION
    $ fakeprovide -a x86_64 \
      -P"libfoo.so.58()(64bit)" \
      -v 4.x foo-libs

    ...
    Processing files: fakeprovide-foo-libs-debugsource-4.x-1.fc35.x86_64
    error: Empty %files file /tmp/rpmspecrMH8z7/rpmbuild/BUILD/fakeprovide-foo-libs-4.x/debugsourcefiles.list

    RPM build errors:
	Empty %files file /tmp/rpmspecrMH8z7/rpmbuild/BUILD/fakeprovide-foo-libs-4.x/debugsourcefiles.list